### PR TITLE
provide tags from Rockylinux 9 for php 8.1, 8.2, 8.3

### DIFF
--- a/.led/service/php.var.yml
+++ b/.led/service/php.var.yml
@@ -3,6 +3,6 @@ vars:
 data:
   VERSION:
     title: PHP version required
-    default: 7.4
+    default: 8.3
     type: list
-    items: 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3
+    items: 5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.1-rl9 8.2-rl9 8.3-rl9

--- a/8.1-rl9/Dockerfile
+++ b/8.1-rl9/Dockerfile
@@ -1,0 +1,80 @@
+FROM rockylinux:9
+
+LABEL org.opencontainers.image.authors="Didier BONNEFOI <dbonnefoi@prestaconcept.net>"
+
+ARG PHP_MAJOR=8.1
+
+RUN dnf clean metadata \
+    && dnf install -y yum-utils https://rpms.remirepo.net/enterprise/remi-release-9.rpm \
+    && dnf module -y reset php \
+    && dnf module -y install php:remi-${PHP_MAJOR} \
+    && crb enable
+
+RUN dnf install -y \
+    php-bcmath \
+    php-cli \
+    php-curl \
+    php-dba \
+    php-dbg \
+    php-enchant \
+    php-fpm \
+    php-ffi \
+    php-gd \
+    php-gettext \
+    php-gmp \
+    php-imap \
+    php-intl \
+    php-ldap \
+    php-litespeed \
+    php-mbstring \
+    php-mysqlnd \
+    php-odbc \
+    php-opcache \
+    php-openssl \
+    php-process \
+    php-pdo \
+    php-pdo-dblib \
+    php-pgsql \
+    php-pspell \
+    php-snmp \
+    php-soap \
+    php-sodium \
+    php-tidy \
+    php-xml
+
+RUN dnf install -y php-pecl-apcu \
+    php-pecl-amqp \
+    php-pecl-ast \
+    php-pecl-http \
+    php-pecl-imagick \
+    php-lz4 \
+    php-pecl-mailparse \
+    php-pecl-memcached \
+    php-pecl-maxminddb \
+    php-pecl-mongodb \
+    php-pecl-pcov \
+    php-pecl-redis \
+    php-pecl-ssh2 \
+    php-pecl-xdebug \
+    php-pecl-zip
+
+RUN dnf module install -y composer:2
+
+RUN dnf install -y make git bash-completion openssh-clients patch \
+    && dnf config-manager --add-repo https://rpm.prestaconcept.net/externals/presta-rhel-externals.repo \
+    && dnf install -y --enablerepo prestaconcept-externals wkhtmltox liberation*fonts \
+    && dnf clean all
+
+RUN ln -sf /usr/share/zoneinfo/Europe/Paris /etc/localtime
+RUN mkdir /run/php-fpm
+
+ADD shared/conf/php/*.ini /etc/php.d/
+
+ADD shared/scripts/entry.sh /entry.sh
+ADD shared/scripts/php_xdebug.sh /
+
+EXPOSE 9000
+
+ENTRYPOINT [ "sh", "/entry.sh" ]
+
+CMD [ "/usr/sbin/php-fpm" ]

--- a/8.1-rl9/Dockerfile
+++ b/8.1-rl9/Dockerfile
@@ -48,7 +48,7 @@ RUN dnf install -y php-pecl-apcu \
     php-pecl-amqp \
     php-pecl-ast \
     php-pecl-http \
-    php-pecl-imagick \
+    php-pecl-imagick-im7 \
     php-lz4 \
     php-pecl-mailparse \
     php-pecl-memcached \

--- a/8.2-rl9/Dockerfile
+++ b/8.2-rl9/Dockerfile
@@ -2,7 +2,7 @@ FROM rockylinux:9
 
 LABEL org.opencontainers.image.authors="Didier BONNEFOI <dbonnefoi@prestaconcept.net>"
 
-ARG PHP_MAJOR=8.1
+ARG PHP_MAJOR=8.2
 ENV ACCEPT_EULA=Y
 
 RUN dnf clean metadata \

--- a/8.2-rl9/Dockerfile
+++ b/8.2-rl9/Dockerfile
@@ -48,7 +48,7 @@ RUN dnf install -y php-pecl-apcu \
     php-pecl-amqp \
     php-pecl-ast \
     php-pecl-http \
-    php-pecl-imagick \
+    php-pecl-imagick-im7 \
     php-lz4 \
     php-pecl-mailparse \
     php-pecl-memcached \

--- a/8.3-rl9/Dockerfile
+++ b/8.3-rl9/Dockerfile
@@ -2,7 +2,7 @@ FROM rockylinux:9
 
 LABEL org.opencontainers.image.authors="Didier BONNEFOI <dbonnefoi@prestaconcept.net>"
 
-ARG PHP_MAJOR=8.1
+ARG PHP_MAJOR=8.3
 ENV ACCEPT_EULA=Y
 
 RUN dnf clean metadata \

--- a/8.3-rl9/Dockerfile
+++ b/8.3-rl9/Dockerfile
@@ -48,7 +48,7 @@ RUN dnf install -y php-pecl-apcu \
     php-pecl-amqp \
     php-pecl-ast \
     php-pecl-http \
-    php-pecl-imagick \
+    php-pecl-imagick-im7 \
     php-lz4 \
     php-pecl-mailparse \
     php-pecl-memcached \

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2023 ledup
+Copyright (c) 2019-2024 ledup
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ ssh2
 XDebug
 ```
 
+(+ `sqlsrv` with some tags)
+
+
 - XDebug is disabled by default. Set an environment variable `PHP_XDEBUG` setted to 1
 - PCOV is disabled by default. Set an environment variable `PHP_PCOV` setted to 1
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Docker image for php-fpm made to use with led.
 
 ### RockyLinux
 
+| Tag         | Description |
+|-------------|-------------|
 | **8.1-rl9** | PHP 8.1.27  |
 | **8.2-rl9** | PHP 8.2.15  |
 | **8.3-rl9** | PHP 8.3.2   |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Docker image for php-fpm made to use with led.
 
 ## Available versions
 
+### CentOS 7
+
 | Tag     | Description |
 |---------|-------------|
 | **5.6** | PHP 5.6.40  |
@@ -17,10 +19,16 @@ Docker image for php-fpm made to use with led.
 | **8.2** | PHP 8.2.15  |
 | **8.3** | PHP 8.3.2   |
 
+### RockyLinux
+
+| **8.1-rl9** | PHP 8.1.27  |
+| **8.2-rl9** | PHP 8.2.15  |
+| **8.3-rl9** | PHP 8.3.2   |
+
 ## Includes
 
-- Composer 2.x (prestaconcept)
-- Git 2 (prestaconcept)
+- Composer 2.x
+- Git
 - Make 3.82
 - Wkhtmltopdf 0.12.6
 


### PR DESCRIPTION
RockyLinux 9 tags (phpX.Y-rl9)
- PHP+Composer from official Remi's RPM repository
- PECL : switch to imagick 7.x 


